### PR TITLE
Add a store of the original function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FunctionWrappersWrappers"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"

--- a/src/FunctionWrappersWrappers.jl
+++ b/src/FunctionWrappersWrappers.jl
@@ -6,6 +6,7 @@ export FunctionWrappersWrapper
 
 struct FunctionWrappersWrapper{FW}
   fw::FW
+  original::Any
 end
 (fww::FunctionWrappersWrapper{FW})(args::Vararg{Any,K}) where {FW,K} = _call(fww.fw, args)
 
@@ -17,7 +18,7 @@ function FunctionWrappersWrapper(f::F, argtypes::Tuple{Vararg{Any,K}}, rettypes:
   fwt = map(argtypes, rettypes) do A, R
     FunctionWrappers.FunctionWrapper{R,A}(f)
   end
-  FunctionWrappersWrapper(fwt)
+  FunctionWrappersWrapper(fwt,f)
 end
 
 end


### PR DESCRIPTION
Otherwise it's impossible to ever unwrap it, which can be required in order to allow more types.

It would nice to also have a fallback where if it's not found in the arg list to just call original, and have a type parameter true/false turn that on/off. 