### PR TITLE
Truncate the stack traces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "0.1.3"
 
 [deps]
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
+TruncatedStacktraces = "781d530d-4396-4725-bb49-402e4bee1e77"
 
 [compat]
 FunctionWrappers = "1"
+TruncatedStacktraces = "1"
 julia = "1.6"
 
 [extras]

--- a/src/FunctionWrappersWrappers.jl
+++ b/src/FunctionWrappersWrappers.jl
@@ -1,12 +1,23 @@
 module FunctionWrappersWrappers
 
 using FunctionWrappers
+import TruncatedStacktraces
 
 export FunctionWrappersWrapper
 
 struct FunctionWrappersWrapper{FW,FB}
   fw::FW
 end
+
+function Base.show(io::IO,
+                    t::Type{FunctionWrappersWrapper{FW,FB}}) where {FW,FB}
+    if TruncatedStacktraces.VERBOSE[]
+        print(io, "FunctionWrappersWrapper{$FW,$FB}")
+    else
+        print(io, "FunctionWrappersWrapper{…}")
+    end
+end
+
 (fww::FunctionWrappersWrapper{FW,FB})(args::Vararg{Any,K}) where {FW,K,FB} = _call(fww.fw, args, fww)
 
 _call(fw::Tuple{FunctionWrappers.FunctionWrapper{R,A},Vararg}, arg::A, fww::FunctionWrappersWrapper) where {R,A} = first(fw)(arg...)


### PR DESCRIPTION
The bundle of FunctionWrapper types is at best difficult to read, at worst not even useful information to anybody. So it should just not be shown by default.