### PR TITLE
Add introspection functions for debugging wrapped functions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "crate-ci/typos"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]

--- a/src/FunctionWrappersWrappers.jl
+++ b/src/FunctionWrappersWrappers.jl
@@ -3,7 +3,7 @@ module FunctionWrappersWrappers
 using FunctionWrappers
 import TruncatedStacktraces
 
-export FunctionWrappersWrapper
+export FunctionWrappersWrapper, unwrap, wrapped_signatures, wrapped_return_types
 
 struct FunctionWrappersWrapper{FW, FB}
     fw::FW
@@ -47,5 +47,71 @@ function FunctionWrappersWrapper(
     end
     FunctionWrappersWrapper{typeof(fwt), FB}(fwt)
 end
+
+"""
+    unwrap(fww::FunctionWrappersWrapper)
+
+Return the original function that was wrapped. This is useful for debugging
+wrapped functions - you can use the returned function with debugging tools
+like Debugger.jl or Infiltrator.jl.
+
+# Example
+
+```julia
+using FunctionWrappersWrappers
+
+# Create a wrapped function
+fww = FunctionWrappersWrapper(sin, (Tuple{Float64},), (Float64,))
+
+# Get the original function for debugging
+f = unwrap(fww)  # Returns sin
+
+# Now you can debug with Debugger.jl:
+# using Debugger
+# @enter f(0.5)
+
+# Or use Infiltrator.jl in your original function definition
+```
+
+See also: [`wrapped_signatures`](@ref), [`wrapped_return_types`](@ref)
+"""
+unwrap(fww::FunctionWrappersWrapper) = first(fww.fw).obj[]
+
+"""
+    wrapped_signatures(fww::FunctionWrappersWrapper)
+
+Return a tuple of the argument type signatures that the `FunctionWrappersWrapper`
+can dispatch on. Each element is a `Tuple` type representing the argument types.
+
+# Example
+
+```julia
+using FunctionWrappersWrappers
+
+fww = FunctionWrappersWrapper(+, (Tuple{Float64, Float64}, Tuple{Int, Int}), (Float64, Int))
+wrapped_signatures(fww)  # Returns (Tuple{Float64, Float64}, Tuple{Int, Int})
+```
+
+See also: [`unwrap`](@ref), [`wrapped_return_types`](@ref)
+"""
+wrapped_signatures(fww::FunctionWrappersWrapper) = map(fw -> typeof(fw).parameters[2], fww.fw)
+
+"""
+    wrapped_return_types(fww::FunctionWrappersWrapper)
+
+Return a tuple of the return types for each wrapped function signature.
+
+# Example
+
+```julia
+using FunctionWrappersWrappers
+
+fww = FunctionWrappersWrapper(+, (Tuple{Float64, Float64}, Tuple{Int, Int}), (Float64, Int))
+wrapped_return_types(fww)  # Returns (Float64, Int64)
+```
+
+See also: [`unwrap`](@ref), [`wrapped_signatures`](@ref)
+"""
+wrapped_return_types(fww::FunctionWrappersWrapper) = map(fw -> typeof(fw).parameters[1], fww.fw)
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,3 +13,54 @@ using Test
     @test fwexp2(4.0f0) === 16.0f0
     @test fwexp2(4) === 16.0
 end
+
+@testset "Introspection functions" begin
+    # Test with a simple function
+    fwsin = FunctionWrappersWrapper(sin, (Tuple{Float64},), (Float64,))
+
+    @testset "unwrap" begin
+        f = unwrap(fwsin)
+        @test f === sin
+        @test f(0.5) == sin(0.5)
+    end
+
+    @testset "wrapped_signatures" begin
+        sigs = wrapped_signatures(fwsin)
+        @test sigs == (Tuple{Float64},)
+    end
+
+    @testset "wrapped_return_types" begin
+        rets = wrapped_return_types(fwsin)
+        @test rets == (Float64,)
+    end
+
+    # Test with multiple signatures
+    fwplus = FunctionWrappersWrapper(+, (Tuple{Float64, Float64}, Tuple{Int, Int}), (Float64, Int))
+
+    @testset "unwrap with multiple signatures" begin
+        f = unwrap(fwplus)
+        @test f === +
+        @test f(1, 2) == 3
+    end
+
+    @testset "wrapped_signatures with multiple signatures" begin
+        sigs = wrapped_signatures(fwplus)
+        @test sigs == (Tuple{Float64, Float64}, Tuple{Int, Int})
+    end
+
+    @testset "wrapped_return_types with multiple signatures" begin
+        rets = wrapped_return_types(fwplus)
+        @test rets == (Float64, Int)
+    end
+
+    # Test with a custom function
+    my_func(x) = x^2
+    fwcustom = FunctionWrappersWrapper(my_func, (Tuple{Float64}, Tuple{Int}), (Float64, Int))
+
+    @testset "unwrap with custom function" begin
+        f = unwrap(fwcustom)
+        @test f === my_func
+        @test f(3) == 9
+        @test f(2.5) == 6.25
+    end
+end


### PR DESCRIPTION
## Summary

This PR addresses issue #18 by adding three new exported functions to help users debug wrapped functions:

- **`unwrap(fww)`**: Returns the original function that was wrapped, allowing users to debug it with tools like Debugger.jl or Infiltrator.jl
- **`wrapped_signatures(fww)`**: Returns a tuple of argument type signatures that the wrapper can dispatch on
- **`wrapped_return_types(fww)`**: Returns a tuple of return types for each wrapped signature

### Example Usage

```julia
using FunctionWrappersWrappers

# Create a wrapped ODE function
my_ode_func(u, p, t) = -0.5 * u
fww = FunctionWrappersWrapper(my_ode_func, (Tuple{Float64, Nothing, Float64},), (Float64,))

# Get the original function for debugging
f = unwrap(fww)  # Returns my_ode_func

# Now you can debug with Debugger.jl:
# using Debugger
# @enter f(1.0, nothing, 0.0)

# View the wrapped type information
wrapped_signatures(fww)    # Returns (Tuple{Float64, Nothing, Float64},)
wrapped_return_types(fww)  # Returns (Float64,)
```

This directly addresses the user's question in #18 about how to step through wrapped functions and export their source code.

## Test Plan

- [x] Added comprehensive tests for all three new functions
- [x] Tests cover single and multiple signature cases
- [x] Tests cover custom functions
- [x] All existing tests still pass

Closes #18

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)