### PR TITLE
Apply JuliaFormatter to introspection functions from #25

### DIFF
--- a/src/FunctionWrappersWrappers.jl
+++ b/src/FunctionWrappersWrappers.jl
@@ -94,7 +94,9 @@ wrapped_signatures(fww)  # Returns (Tuple{Float64, Float64}, Tuple{Int, Int})
 
 See also: [`unwrap`](@ref), [`wrapped_return_types`](@ref)
 """
-wrapped_signatures(fww::FunctionWrappersWrapper) = map(fw -> typeof(fw).parameters[2], fww.fw)
+function wrapped_signatures(fww::FunctionWrappersWrapper)
+    map(fw -> typeof(fw).parameters[2], fww.fw)
+end
 
 """
     wrapped_return_types(fww::FunctionWrappersWrapper)
@@ -112,6 +114,8 @@ wrapped_return_types(fww)  # Returns (Float64, Int64)
 
 See also: [`unwrap`](@ref), [`wrapped_signatures`](@ref)
 """
-wrapped_return_types(fww::FunctionWrappersWrapper) = map(fw -> typeof(fw).parameters[1], fww.fw)
+function wrapped_return_types(fww::FunctionWrappersWrapper)
+    map(fw -> typeof(fw).parameters[1], fww.fw)
+end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,8 @@ end
     end
 
     # Test with multiple signatures
-    fwplus = FunctionWrappersWrapper(+, (Tuple{Float64, Float64}, Tuple{Int, Int}), (Float64, Int))
+    fwplus = FunctionWrappersWrapper(+, (Tuple{Float64, Float64}, Tuple{Int, Int}), (
+        Float64, Int))
 
     @testset "unwrap with multiple signatures" begin
         f = unwrap(fwplus)
@@ -55,7 +56,8 @@ end
 
     # Test with a custom function
     my_func(x) = x^2
-    fwcustom = FunctionWrappersWrapper(my_func, (Tuple{Float64}, Tuple{Int}), (Float64, Int))
+    fwcustom = FunctionWrappersWrapper(my_func, (Tuple{Float64}, Tuple{Int}), (
+        Float64, Int))
 
     @testset "unwrap with custom function" begin
         f = unwrap(fwcustom)


### PR DESCRIPTION
## Summary

This PR applies JuliaFormatter to the code introduced in #25 to fix the format check CI.

- Converts one-line function definitions to multi-line format per SciMLStyle
- Wraps long lines in tests

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)