### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
+      - 'master'
       - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-suggestions-on-pr.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,10 @@
 using FunctionWrappersWrappers
 using Documenter
 
-DocMeta.setdocmeta!(FunctionWrappersWrappers, :DocTestSetup,
-    :(using FunctionWrappersWrappers); recursive = true)
+DocMeta.setdocmeta!(
+    FunctionWrappersWrappers, :DocTestSetup,
+    :(using FunctionWrappersWrappers); recursive = true
+)
 
 makedocs(;
     modules = [FunctionWrappersWrappers],

--- a/src/FunctionWrappersWrappers.jl
+++ b/src/FunctionWrappersWrappers.jl
@@ -12,16 +12,20 @@ end
 TruncatedStacktraces.@truncate_stacktrace FunctionWrappersWrapper
 
 function (fww::FunctionWrappersWrapper{FW, FB})(args::Vararg{Any, K}) where {FW, K, FB}
-    _call(fww.fw, args, fww)
+    return _call(fww.fw, args, fww)
 end
 
-function _call(fw::Tuple{FunctionWrappers.FunctionWrapper{R, A}, Vararg},
-        arg::A, fww::FunctionWrappersWrapper) where {R, A}
-    first(fw)(arg...)
+function _call(
+        fw::Tuple{FunctionWrappers.FunctionWrapper{R, A}, Vararg},
+        arg::A, fww::FunctionWrappersWrapper
+    ) where {R, A}
+    return first(fw)(arg...)
 end
-function _call(fw::Tuple{FunctionWrappers.FunctionWrapper{R, A1}, Vararg},
-        arg::A2, fww::FunctionWrappersWrapper) where {R, A1, A2}
-    _call(Base.tail(fw), arg, fww)
+function _call(
+        fw::Tuple{FunctionWrappers.FunctionWrapper{R, A1}, Vararg},
+        arg::A2, fww::FunctionWrappersWrapper
+    ) where {R, A1, A2}
+    return _call(Base.tail(fw), arg, fww)
 end
 
 const NO_FUNCTIONWRAPPER_FOUND_MESSAGE = "No matching function wrapper was found!"
@@ -29,23 +33,24 @@ const NO_FUNCTIONWRAPPER_FOUND_MESSAGE = "No matching function wrapper was found
 struct NoFunctionWrapperFoundError <: Exception end
 
 function Base.showerror(io::IO, e::NoFunctionWrapperFoundError)
-    print(io, NO_FUNCTIONWRAPPER_FOUND_MESSAGE)
+    return print(io, NO_FUNCTIONWRAPPER_FOUND_MESSAGE)
 end
 
 function _call(::Tuple{}, arg, fww::FunctionWrappersWrapper{<:Any, false})
     throw(NoFunctionWrapperFoundError())
 end
 function _call(::Tuple{}, arg, fww::FunctionWrappersWrapper{<:Any, true})
-    first(fww.fw).obj[](arg...)
+    return first(fww.fw).obj[](arg...)
 end
 
 function FunctionWrappersWrapper(
         f::F, argtypes::Tuple{Vararg{Any, K}}, rettypes::Tuple{Vararg{DataType, K}},
-        fallback::Val{FB} = Val{false}()) where {F, K, FB}
+        fallback::Val{FB} = Val{false}()
+    ) where {F, K, FB}
     fwt = map(argtypes, rettypes) do A, R
         FunctionWrappers.FunctionWrapper{R, A}(f)
     end
-    FunctionWrappersWrapper{typeof(fwt), FB}(fwt)
+    return FunctionWrappersWrapper{typeof(fwt), FB}(fwt)
 end
 
 """
@@ -95,7 +100,7 @@ wrapped_signatures(fww)  # Returns (Tuple{Float64, Float64}, Tuple{Int, Int})
 See also: [`unwrap`](@ref), [`wrapped_return_types`](@ref)
 """
 function wrapped_signatures(fww::FunctionWrappersWrapper)
-    map(fw -> typeof(fw).parameters[2], fww.fw)
+    return map(fw -> typeof(fw).parameters[2], fww.fw)
 end
 
 """
@@ -115,7 +120,7 @@ wrapped_return_types(fww)  # Returns (Float64, Int64)
 See also: [`unwrap`](@ref), [`wrapped_signatures`](@ref)
 """
 function wrapped_return_types(fww::FunctionWrappersWrapper)
-    map(fw -> typeof(fw).parameters[1], fww.fw)
+    return map(fw -> typeof(fw).parameters[1], fww.fw)
 end
 
 using PrecompileTools

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,13 +2,17 @@ using FunctionWrappersWrappers
 using Test
 
 @testset "FunctionWrappersWrappers.jl" begin
-    fwplus = FunctionWrappersWrapper(+, (Tuple{Float64, Float64}, Tuple{Int, Int}), (
-        Float64, Int));
+    fwplus = FunctionWrappersWrapper(
+        +, (Tuple{Float64, Float64}, Tuple{Int, Int}), (
+            Float64, Int,
+        )
+    )
     @test fwplus(4.0, 8.0) === 12.0
     @test fwplus(4, 8) === 12
 
     fwexp2 = FunctionWrappersWrapper(
-        exp2, (Tuple{Float64}, Tuple{Float32}, Tuple{Int}), (Float64, Float32, Float64));
+        exp2, (Tuple{Float64}, Tuple{Float32}, Tuple{Int}), (Float64, Float32, Float64)
+    )
     @test fwexp2(4.0) === 16.0
     @test fwexp2(4.0f0) === 16.0f0
     @test fwexp2(4) === 16.0
@@ -35,8 +39,11 @@ end
     end
 
     # Test with multiple signatures
-    fwplus = FunctionWrappersWrapper(+, (Tuple{Float64, Float64}, Tuple{Int, Int}), (
-        Float64, Int))
+    fwplus = FunctionWrappersWrapper(
+        +, (Tuple{Float64, Float64}, Tuple{Int, Int}), (
+            Float64, Int,
+        )
+    )
 
     @testset "unwrap with multiple signatures" begin
         f = unwrap(fwplus)
@@ -56,8 +63,11 @@ end
 
     # Test with a custom function
     my_func(x) = x^2
-    fwcustom = FunctionWrappersWrapper(my_func, (Tuple{Float64}, Tuple{Int}), (
-        Float64, Int))
+    fwcustom = FunctionWrappersWrapper(
+        my_func, (Tuple{Float64}, Tuple{Int}), (
+            Float64, Int,
+        )
+    )
 
     @testset "unwrap with custom function" begin
         f = unwrap(fwcustom)


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)