### PR TITLE
Fix Mooncake extension: use build_rrule + fdata (v1.2.1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FunctionWrappersWrappers"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"

--- a/ext/FunctionWrappersWrappersMooncakeExt.jl
+++ b/ext/FunctionWrappersWrappersMooncakeExt.jl
@@ -2,7 +2,7 @@ module FunctionWrappersWrappersMooncakeExt
 
 using FunctionWrappersWrappers
 import Mooncake
-using Mooncake: @is_primitive, MinimalCtx, CoDual, NoRData, zero_tangent, NoTangent
+using Mooncake: @is_primitive, MinimalCtx, CoDual, NoRData, zero_tangent, NoTangent, fdata
 
 # Make calling a FunctionWrappersWrapper a Mooncake primitive.
 # Instead of differentiating through the FunctionWrapper dispatch machinery
@@ -16,9 +16,16 @@ function Mooncake.rrule!!(
         f::CoDual{<:FunctionWrappersWrapper}, args::Vararg{CoDual},
     )
     f_orig = unwrap(f.x)
-    f_orig_codual = CoDual(f_orig, zero_tangent(f_orig))
-    y, pb = Mooncake.rrule!!(f_orig_codual, args...)
-    fww_pb(dy) = (NoRData(), Mooncake.Base.tail(pb(dy))...)
+    # Build a derived rule for calling the unwrapped function with these arg types.
+    # We can't use rrule!! directly since the unwrapped function (e.g. SciMLBase.Void)
+    # is generally not a Mooncake primitive — it needs a derived (compiled) rule.
+    sig = Tuple{typeof(f_orig), map(Core.Typeof ∘ Mooncake.primal, args)...}
+    rule = Mooncake.build_rrule(sig)
+    # Use fdata to get the correct tangent component for the CoDual — zero_tangent
+    # returns NoTangent for singleton callables but derived rules expect NoFData.
+    f_orig_codual = CoDual(f_orig, fdata(zero_tangent(f_orig)))
+    y, pb = rule(f_orig_codual, args...)
+    fww_pb(dy) = (NoRData(), Base.tail(pb(dy))...)
     return y, fww_pb
 end
 

--- a/test/mooncake_tests.jl
+++ b/test/mooncake_tests.jl
@@ -45,6 +45,47 @@ end
     @test dx ≈ [6.0, 8.0]
 end
 
+@testset "Mooncake with wrapped callable struct" begin
+    # SciML wraps functions in Void{F} or similar callable structs before
+    # putting them in FunctionWrappersWrapper. The unwrapped function is
+    # then a non-primitive callable struct, not a plain function.
+    struct VoidWrapper{F}
+        f::F
+    end
+    function (v::VoidWrapper)(args...)
+        v.f(args...)
+        return nothing
+    end
+
+    function f!(du, u, p)
+        du[1] = p[1] * u[1]
+        du[2] = p[2] * u[2]
+        return nothing
+    end
+
+    wrapped = VoidWrapper(f!)
+    fww = FunctionWrappersWrapper(
+        wrapped,
+        (Tuple{Vector{Float64}, Vector{Float64}, Vector{Float64}},),
+        (Nothing,),
+    )
+
+    function loss(p)
+        u = [3.0, 4.0]
+        du = similar(u)
+        fww(du, u, p)
+        return sum(abs2, du)
+    end
+
+    rule = Mooncake.build_rrule(loss, [2.0, 3.0])
+    val, (_, dp) = Mooncake.value_and_gradient!!(rule, loss, [2.0, 3.0])
+    # du = [2*3, 3*4] = [6, 12], loss = 36 + 144 = 180
+    @test val ≈ 180.0
+    # ∂loss/∂p1 = 2*du[1]*u[1] = 2*6*3 = 36
+    # ∂loss/∂p2 = 2*du[2]*u[2] = 2*12*4 = 96
+    @test dp ≈ [36.0, 96.0]
+end
+
 @testset "Mooncake in-place function" begin
     # In-place functions are common in SciML (f!(du, u, p, t))
     function f!(du, u, p)


### PR DESCRIPTION
## Summary

Fix two bugs in the v1.2.0 Mooncake extension that cause `MethodError` when differentiating through `FunctionWrappersWrapper`.

## Bugs fixed

1. **`rrule!!` → `build_rrule`**: `rrule!!` only works for Mooncake primitives. The unwrapped function (e.g. `SciMLBase.Void{typeof(f)}`) is not a primitive — `build_rrule` creates a derived rule that handles arbitrary callables.

2. **`zero_tangent` → `fdata(zero_tangent(...))`**: `zero_tangent` returns `NoTangent` for singleton callables, but derived rules expect `NoFData` (the fdata component of the tangent).

## Verified

```
v1.2.0 (rrule!! approach):
  Plain function: FAILED — MethodError: no method matching rrule!!
  VoidWrapper:    FAILED — MethodError: no method matching rrule!!

v1.2.1 (build_rrule + fdata):
  Plain function: val=9.0, dx=6.0 — PASS
  VoidWrapper:    val=180.0, dp=[36.0, 96.0] — PASS
```

## Test added

`VoidWrapper` callable struct test — exercises the exact pattern used by SciML's `AutoSpecialize` where the unwrapped function is a struct wrapping the actual function, not a plain function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)