### PR TITLE
Declare cache-storage types as Enzyme inactive

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FunctionWrappersWrappers"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "1.9.0"
+version = "1.9.1"
 
 [deps]
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"

--- a/ext/FunctionWrappersWrappersEnzymeExt.jl
+++ b/ext/FunctionWrappersWrappersEnzymeExt.jl
@@ -1,9 +1,25 @@
 module FunctionWrappersWrappersEnzymeExt
 
 using FunctionWrappersWrappers
+using FunctionWrappersWrappers: SingleCacheStorage, DictCacheStorage, NoCacheStorage
 using Enzyme
 using EnzymeCore
 using EnzymeCore.EnzymeRules
+
+# =============================================================================
+# Mark cache-storage types as inactive
+# =============================================================================
+# `SingleCacheStorage` and `DictCacheStorage` are mutable / contain a `Dict`,
+# and their cache-miss branches write to that storage. Without these
+# declarations Enzyme conservatively treats any closure that *might* touch a
+# `FunctionWrappersWrapper` (e.g. via `remake(prob; p = …)` capturing the
+# problem in scope) as potentially writing to the wrapper's cache, and
+# refuses to prove the captured argument read-only. The cache values are
+# `FunctionWrapper`s used purely for dispatch / dynamic call speedup; they
+# never hold derivative data.
+EnzymeCore.EnzymeRules.inactive_type(::Type{<:SingleCacheStorage}) = true
+EnzymeCore.EnzymeRules.inactive_type(::Type{<:DictCacheStorage}) = true
+EnzymeCore.EnzymeRules.inactive_type(::Type{NoCacheStorage}) = true
 
 # =============================================================================
 # Helper: build a Forward mode from FwdConfig flags


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

`SingleCacheStorage` is a mutable struct and `DictCacheStorage` carries a mutable `Dict`. The `_fallback` paths write a `FunctionWrapper` into the storage on a cache miss. Without an `inactive_type` declaration Enzyme conservatively treats any closure that captures a `FunctionWrappersWrapper` as potentially writing to the storage, so `Enzyme.gradient` / `autodiff` through such a closure can fail with `EnzymeMutabilityException` on the captured argument.

The cache values are `FunctionWrapper`s used purely for dispatch and dynamic-call speedup — they never carry derivative data. Marking the three storage types `inactive_type` lets Enzyme prove the captured wrapper readonly without affecting derivative correctness.

## Honest caveat

This is **defensive hardening**, not a load-bearing fix on its own. The investigation that prompted this PR (Enzyme through MTK `remake` + `solve`, see SciML/SciMLSensitivity.jl#1323, #1359, SciML/ModelingToolkit.jl#4550) shows that the layer-2 failure persists even with this declaration in place — there's a separate Enzyme + NonlinearSolve interaction against the wrapped function. Filing this as a clean, narrow improvement that removes one conservative-IPA layer for any user of FWW under Enzyme; the deeper fix is upstream.

## Refs

- SciML/SciMLSensitivity.jl#1323, #1359
- SciML/ModelingToolkit.jl#4550, #4551