### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -18,26 +18,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
 
 jobs:
-  test:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Core
-          - nopre
-        version:
-          - '1'
-          - 'lts'
-          - 'pre'
-        arch:
-          - x64
-        exclude:
-          - version: 'pre'
-            group: 'nopre'
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
-      julia-arch: "${{ matrix.arch }}"
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,5 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[nopre]
+versions = ["lts", "1"]


### PR DESCRIPTION
This converts the root test workflow (`Tests.yml`) to the canonical thin caller of `SciML/.github` `grouped-tests.yml@v1`, with the test matrix declared once in a root `test/test_groups.toml`.

## Changes

- **`.github/workflows/Tests.yml`**: the hand-maintained `group x version` matrix test job is replaced with the thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
  The `on:` triggers, `concurrency:`, filename, and top-level `name: "Tests"` are preserved verbatim so the branch-protection status check is unaffected.
- **`test/test_groups.toml`** (new): declares the matrix
  ```toml
  [Core]
  versions = ["lts", "1", "pre"]

  [nopre]
  versions = ["lts", "1"]
  ```

No `with:` inputs are needed: `runtests.jl` reads the standard `GROUP` env var (default `group-env-name`), coverage stays on, `check-bounds` stays at the default `yes` (the old caller also used the default), and `coverage-directories` stays at the default `src,ext`. Linux-only, so no `os` axis is added (default `ubuntu-latest`, matching the old `arch: x64` on `ubuntu-latest`).

This is a Category A conversion: the `Core`/`nopre` `GROUP` dispatch already exists in `test/runtests.jl`, so there is no test-runner change and no new local Aqua/QA run was required.

## Matrix match

Verified with `compute_affected_sublibraries.jl --root-matrix` (from `SciML/.github@v1`). The emitted `(group, version)` set reproduces the old workflow matrix **exactly, 5/5**:

| group | versions |
|-------|----------|
| Core  | lts, 1, pre |
| nopre | lts, 1 (pre excluded, as before) |

All runners are `ubuntu-latest`. TOML and YAML both parse cleanly.

## QA findings

None. No metadata fixes were needed (`[compat] julia` is already at the `1.10` LTS floor; `[extras]`/`[targets].test` are aligned). No source-level Aqua/JET issues to report.

Note (not addressed here, pre-existing): `runtests.jl` also has `Enzyme` and `Mooncake` `GROUP` branches that only run under `GROUP=All`. The old `Tests.yml` matrix never dispatched `All`/`Enzyme`/`Mooncake`, so those extension testsets did not run in CI before this PR either. To keep this an exact, behavior-preserving matrix conversion, they are intentionally not added here; expanding CI to cover them can be a separate change.

Ignore until reviewed by @ChrisRackauckas.