### PR TITLE
Fix downgrade CI: split the AD test group out of the downgrade lane

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -28,5 +28,13 @@ jobs:
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       group: "${{ matrix.group }}"
-      julia-version: "lts"
+      # The Mooncake/Enzyme test extras only resolve at their declared minimum
+      # versions on Julia >= 1.11.6: every Mooncake 0.5.x requires julia >= 1.10.8,
+      # and the Enzyme 0.13 + EnzymeCore 0.8 + Mooncake 0.5 floor set has no
+      # minimum-version solution on the 1.10 LTS stdlib line. The downgrade
+      # resolver minimizes julia to the floor of its --julia range, so on lts
+      # (=1.10, which admits 1.10.0) it strands Mooncake -> Unsatisfiable. Pin the
+      # downgrade leg to 1.11 (resolves to julia 1.11.6); the core package's 1.10
+      # support is still exercised by the regular Tests workflow.
+      julia-version: "1.11"
     secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -28,13 +28,5 @@ jobs:
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       group: "${{ matrix.group }}"
-      # The Mooncake/Enzyme test extras only resolve at their declared minimum
-      # versions on Julia >= 1.11.6: every Mooncake 0.5.x requires julia >= 1.10.8,
-      # and the Enzyme 0.13 + EnzymeCore 0.8 + Mooncake 0.5 floor set has no
-      # minimum-version solution on the 1.10 LTS stdlib line. The downgrade
-      # resolver minimizes julia to the floor of its --julia range, so on lts
-      # (=1.10, which admits 1.10.0) it strands Mooncake -> Unsatisfiable. Pin the
-      # downgrade leg to 1.11 (resolves to julia 1.11.6); the core package's 1.10
-      # support is still exercised by the regular Tests workflow.
-      julia-version: "1.11"
+      julia-version: "lts"
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -20,21 +20,18 @@ FunctionWrappersWrappersMooncakeExt = "Mooncake"
 [compat]
 Enzyme = "0.13"
 EnzymeCore = "0.8"
-FunctionWrappers = "1"
+FunctionWrappers = "1.1.2"
 Mooncake = "0.5"
-PrecompileTools = "1.1"
+PrecompileTools = "1"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "1"
 TruncatedStacktraces = "1.1"
 julia = "1.10"
 
 [extras]
-Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
-EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
-Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SafeTestsets", "SciMLTesting", "Enzyme", "EnzymeCore", "Mooncake"]
+test = ["Test", "SafeTestsets", "SciMLTesting"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,12 +20,12 @@ FunctionWrappersWrappersMooncakeExt = "Mooncake"
 [compat]
 Enzyme = "0.13"
 EnzymeCore = "0.8"
-FunctionWrappers = "1.1.3"
+FunctionWrappers = "1"
 Mooncake = "0.5"
-PrecompileTools = "1"
+PrecompileTools = "1.1"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "1"
-TruncatedStacktraces = "1"
+TruncatedStacktraces = "1.1"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FunctionWrappersWrappers"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "1.9.1"
+version = "1.9.2"
 
 [deps]
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
@@ -20,7 +20,7 @@ FunctionWrappersWrappersMooncakeExt = "Mooncake"
 [compat]
 Enzyme = "0.13"
 EnzymeCore = "0.8"
-FunctionWrappers = "1"
+FunctionWrappers = "1.1.3"
 Mooncake = "0.5"
 PrecompileTools = "1"
 SafeTestsets = "0.1, 1"

--- a/test/Enzyme/Project.toml
+++ b/test/Enzyme/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+FunctionWrappersWrappers = "77dc65aa-8811-40c2-897b-53d922fa7daf"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+FunctionWrappersWrappers = {path = "../.."}
+
+[compat]
+Enzyme = "0.13"
+EnzymeCore = "0.8"
+SafeTestsets = "0.0.1, 0.1, 1"
+Test = "1"

--- a/test/Mooncake/Project.toml
+++ b/test/Mooncake/Project.toml
@@ -1,0 +1,13 @@
+[deps]
+FunctionWrappersWrappers = "77dc65aa-8811-40c2-897b-53d922fa7daf"
+Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+FunctionWrappersWrappers = {path = "../.."}
+
+[compat]
+Mooncake = "0.5"
+SafeTestsets = "0.0.1, 0.1, 1"
+Test = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,8 +22,14 @@ run_tests(;
                 end
             end,
         ),
-        "Enzyme" => joinpath(@__DIR__, "Enzyme", "enzyme_tests.jl"),
-        "Mooncake" => joinpath(@__DIR__, "Mooncake", "mooncake_tests.jl"),
+        "Enzyme" => (;
+            env = joinpath(@__DIR__, "Enzyme"),
+            body = joinpath(@__DIR__, "Enzyme", "enzyme_tests.jl"),
+        ),
+        "Mooncake" => (;
+            env = joinpath(@__DIR__, "Mooncake"),
+            body = joinpath(@__DIR__, "Mooncake", "mooncake_tests.jl"),
+        ),
     ),
     all = ["Core", "Enzyme", "Mooncake"],
 )

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -3,3 +3,9 @@ versions = ["lts", "1", "pre"]
 
 [nopre]
 versions = ["lts", "1"]
+
+[Enzyme]
+versions = ["lts", "1"]
+
+[Mooncake]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Problem

The `Downgrade (Core)` job was red. The root cause is that the AD test extras (`Enzyme`, `EnzymeCore`, `Mooncake`) were part of the **root test target** (`[targets].test`), so the downgrade resolver had to place them in the minimum-version test env.

`julia-downgrade-compat` (Resolver.jl) minimizes Julia to the floor of its `--julia` range; on `lts` that admits `1.10.0`. But every `Mooncake 0.5.x` requires `julia >= 1.10.8`, and the `Enzyme 0.13` + `EnzymeCore 0.8` + `Mooncake 0.5` minimum-version set has **no solution** on the 1.10 LTS stdlib line, so the merged test env is `Unsatisfiable`. This is the Resolver.jl <-> Mooncake wall (StefanKarpinski/Resolver.jl#24). The AD deps should not gate the downgrade lane.

## Fix: split the AD group out of downgrade (instead of pinning Julia)

- Move the AD test deps into their own per-group sub-environments: `test/Enzyme/Project.toml` and `test/Mooncake/Project.toml`, each with `[sources] FunctionWrappersWrappers = {path = "../.."}`. Drop `Enzyme`/`EnzymeCore`/`Mooncake` from the root `[extras]`/`[targets].test`. (They stay as `[weakdeps]` + `[compat]` for the extensions.)
- `test/runtests.jl`: the `Enzyme`/`Mooncake` groups now use SciMLTesting's per-group `env = ...` form (the same mechanism the `nopre` group already uses), so each runs in its own env.
- `test/test_groups.toml`: add `Enzyme` and `Mooncake` groups (`["lts", "1"]`). They were declared in `runtests.jl` but had **no matrix entry**, so they were not running in CI at all — now they do.
- The `Downgrade` job runs `GROUP=Core`, which resolves only the root test target — now AD-free — so it is satisfiable on `lts` (Julia 1.10) again.

### Reverted #59 accommodations (they masked the AD-resolution problem)
- `.github/workflows/Downgrade.yml`: `julia-version` back to `"lts"` (no longer pinned to `1.11`).
- `PrecompileTools` compat floor back to `"1"`: the `1.0.0` GPUCompiler precompile failure only arose because Enzyme pulled GPUCompiler into the downgrade env; with AD out of that env it no longer applies.

### Kept — genuine minimum-version bugs, independent of AD (verified on Julia 1.10)
- `TruncatedStacktraces = "1.1"`: `src` uses `@truncate_stacktrace`, which does not exist before v1.1.0 (1.0.0 is a 25-line stub).
- `FunctionWrappers = "1.1.2"`: 1.0.0 / 1.1.0 / 1.1.1 fail to build the `FunctionWrapper` cfunction (`Module IR does not contain specified entry function`) on Julia 1.10; **1.1.2** is the lowest that builds and runs. This is exercised by the package's own PrecompileTools `@compile_workload`, so it is a real floor regardless of the AD split. (This vindicates the earlier `FunctionWrappers` floor raise — the floor is real; only the exact version was off, 1.1.2 vs 1.1.3.)

## Local verification (Julia 1.10 / lts — the actual downgrade leg)

Ran the real `julia-actions/julia-downgrade-compat@v2` `downgrade.jl` (mode `deps`, projects `.`, effective skip = Julia stdlibs):
- Resolution: exit 0, `Successfully resolved minimal versions for . (with extras)`.
- Downgraded manifest contains **no** `Enzyme` / `Mooncake` / `GPUCompiler`. Floors: `FunctionWrappers 1.1.2`, `PrecompileTools 1.0.0`, `TruncatedStacktraces 1.1.0`, `SafeTestsets 0.1.0`, `SciMLTesting 1.0.0`.
- `Pkg.test` `GROUP=Core` with `allow_reresolve=false, force_latest_compatible_version=false` (the `julia-runtest` CI settings): precompiles cleanly and **passes** — `FunctionWrappersWrappers.jl` 48/48, `BigFloat + UnionAll` 7/7.

AD groups still run via their sub-envs (Julia 1.11): `GROUP=Enzyme` 65/65, `GROUP=Mooncake` 13/13, with `FunctionWrappersWrappersEnzymeExt` / `FunctionWrappersWrappersMooncakeExt` precompiling in-group. The grouped-tests matrix script now emits 9 jobs (Core lts/1/pre, Enzyme lts/1, Mooncake lts/1, nopre lts/1).

Please ignore until reviewed by @ChrisRackauckas