### PR TITLE
Release prep: bump FunctionWrappersWrappers to 1.10.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FunctionWrappersWrappers"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "1.10.0"
+version = "1.10.1"
 
 [deps]
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test scaffolding changes since 1.10.0; version-only change to Project.toml.