### PR TITLE
Implement a constructor for an existing FunctionWrapper

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FunctionWrappersWrappers"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "1.10.1"
+version = "1.11.0"
 
 [deps]
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 FunctionWrappersWrappers = "77dc65aa-8811-40c2-897b-53d922fa7daf"
 
 [compat]

--- a/src/FunctionWrappersWrappers.jl
+++ b/src/FunctionWrappersWrappers.jl
@@ -283,6 +283,47 @@ function FunctionWrappersWrapper(
     return FunctionWrappersWrapper{typeof(fwt), typeof(policy), typeof(cs)}(fwt, cs)
 end
 
+"""
+    FunctionWrappersWrapper(fw::Tuple{Vararg{FunctionWrappers.FunctionWrapper}}; cache=SingleCache(), policy=AllowNonIsBits())
+
+Create a callable wrapper from already-constructed `FunctionWrapper`s.
+
+Use this when the `FunctionWrapper`s must be built by the caller, for instance to keep
+construction inferrable: the `argtypes`/`rettypes` method takes its types as values, so the
+wrapper type is only inferred when those values constant-propagate. Building `fw` with the
+signatures bound as type parameters and passing it here keeps `typeof(fww)` concrete.
+
+# Arguments
+- `fw`: Tuple of `FunctionWrappers.FunctionWrapper`s, tried in order on call.
+
+# Keyword Arguments
+- `cache`: Fallback cache mode. Defaults to `SingleCache()`.
+- `policy`: Fallback policy. Defaults to `AllowNonIsBits()`.
+
+# Returns
+- `FunctionWrappersWrapper`: A callable wrapper around `fw`.
+
+# Examples
+```jldoctest
+julia> using FunctionWrappers: FunctionWrapper
+
+julia> fw = (FunctionWrapper{Float64, Tuple{Float64, Float64}}(+),);
+
+julia> fww = FunctionWrappersWrapper(fw);
+
+julia> fww(1.0, 2.0)
+3.0
+```
+"""
+function FunctionWrappersWrapper(
+        fw::Tuple{Vararg{FunctionWrappers.FunctionWrapper}};
+        cache::AbstractCacheMode = SingleCache(),
+        policy::AbstractFallbackPolicy = AllowNonIsBits()
+    )
+    cs = _make_cache_storage(cache)
+    return FunctionWrappersWrapper{typeof(fw), typeof(policy), typeof(cs)}(fw, cs)
+end
+
 Base.convert(::Type{T}, obj) where {T <: FunctionWrappersWrapper} = T(obj)
 Base.convert(::Type{T}, obj::T) where {T <: FunctionWrappersWrapper} = obj
 

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -244,6 +244,38 @@ end
     @test_throws FunctionWrappersWrappers.NoFunctionWrapperFoundError fww(4.0f0, 8.0f0)
 end
 
+@testset "Construction from FunctionWrappers" begin
+    using FunctionWrappers: FunctionWrapper
+
+    fw = (
+        FunctionWrapper{Float64, Tuple{Float64, Float64}}(+),
+        FunctionWrapper{Int, Tuple{Int, Int}}(+),
+    )
+    argtypes = (Tuple{Float64, Float64}, Tuple{Int, Int})
+    rettypes = (Float64, Int)
+
+    fww = FunctionWrappersWrapper(fw)
+    @test fww(4.0, 8.0) === 12.0
+    @test fww(4, 8) === 12
+    # Same wrapper the argtypes/rettypes constructor builds, defaults included
+    @test typeof(fww) === typeof(FunctionWrappersWrapper(+, argtypes, rettypes))
+
+    strict = FunctionWrappersWrapper(fw; policy = Strict(), cache = NoCache())
+    @test typeof(strict) === typeof(
+        FunctionWrappersWrapper(
+            +, argtypes, rettypes; policy = Strict(), cache = NoCache()
+        )
+    )
+    @test_throws FunctionWrappersWrappers.NoFunctionWrapperFoundError strict(
+        BigFloat(4), BigFloat(8)
+    )
+
+    # The point of this constructor: the wrapper type stays concrete even when the
+    # wrapped callable is opaque to inference.
+    make(f) = FunctionWrappersWrapper((FunctionWrapper{Float64, Tuple{Float64}}(f),))
+    @test isconcretetype(only(Base.return_types(make, (Function,))))
+end
+
 @testset "Conversion" begin
     fww_exp = FunctionWrappersWrapper(
         exp,


### PR DESCRIPTION
Allows for creating a wrapper without having to reach into internals.

The main motivation is to get rid of reaching into FWW internals here (`SingleCacheStorage`): https://github.com/SciML/NonlinearSolve.jl/blob/b491a4e8d787a0241843a9846e3b917bd7243364/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl#L85
Which is causing QA failures on https://github.com/SciML/NonlinearSolve.jl/pull/1051: https://github.com/SciML/NonlinearSolve.jl/actions/runs/29238046189/job/86779012609?pr=1051

But it also seems like a useful API to have in general.

Written with help from Claude :robot: 

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API