### PR TITLE
Document cache storage public APIs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.10.1"
 [deps]
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 TruncatedStacktraces = "781d530d-4396-4725-bb49-402e4bee1e77"
 
 [weakdeps]
@@ -24,6 +25,7 @@ FunctionWrappers = "1.1.2"
 Mooncake = "0.5"
 PrecompileTools = "1.1"
 SafeTestsets = "0.1, 1"
+SciMLPublic = "1"
 SciMLTesting = "2.1"
 Test = "1"
 TruncatedStacktraces = "1.1"

--- a/src/FunctionWrappersWrappers.jl
+++ b/src/FunctionWrappersWrappers.jl
@@ -96,6 +96,29 @@ struct AllowNonIsBits <: AbstractFallbackPolicy end
 # ============================================================================
 # Cache storage types
 # ============================================================================
+"""
+    NoCacheStorage()
+
+Storage marker for the `NoCache()` fallback mode.
+
+`NoCacheStorage` carries no state. Use this type when constructing or
+inspecting a `FunctionWrappersWrapper` whose fallback path should dispatch
+through the original function without caching generated
+`FunctionWrappers.FunctionWrapper`s.
+
+# Examples
+
+```julia
+using FunctionWrappersWrappers
+
+wrapper = FunctionWrappersWrapper(sin, (Tuple{Float64},), (Float64,);
+    cache = NoCache(), policy = AllowAll())
+storage = FunctionWrappersWrappers.NoCacheStorage()
+```
+
+# Returns
+- `NoCacheStorage`: Empty storage marker for uncached fallback calls.
+"""
 struct NoCacheStorage end
 
 """
@@ -104,21 +127,23 @@ struct NoCacheStorage end
 Storage for the `SingleCache()` fallback mode.
 
 `SingleCacheStorage` stores one fallback `FunctionWrappers.FunctionWrapper`
-for the most recent argument tuple type. It is public so downstream packages
-that manually construct `FunctionWrappersWrapper` values can select the same
-single-entry cache layout used by `FunctionWrappersWrapper(...; cache = SingleCache())`.
+for the most recent argument tuple type. Use this type when constructing or
+inspecting a `FunctionWrappersWrapper` that should reuse a single cached
+fallback wrapper before replacing it on a different fallback argument tuple
+type.
 
 # Examples
 
 ```julia
 using FunctionWrappersWrappers
 
-storage = FunctionWrappersWrappers.SingleCacheStorage()
 wrapper = FunctionWrappersWrapper(sin, (Tuple{Float64},), (Float64,);
-    cache = SingleCache())
-
-wrapper(1.0)
+    cache = SingleCache(), policy = AllowAll())
+storage = FunctionWrappersWrappers.SingleCacheStorage()
 ```
+
+# Fields
+- `cached`: The cached fallback wrapper, or `nothing` before fallback is used.
 
 # Returns
 - `SingleCacheStorage`: Empty storage for one cached fallback wrapper.
@@ -127,12 +152,39 @@ mutable struct SingleCacheStorage
     cached::Any  # Union{Nothing, FunctionWrapper}
     SingleCacheStorage() = new(nothing)
 end
-@public SingleCacheStorage
 
+"""
+    DictCacheStorage()
+
+Storage for the `DictCache()` fallback mode.
+
+`DictCacheStorage` stores fallback `FunctionWrappers.FunctionWrapper`s keyed by
+argument tuple type. Use this type when constructing or inspecting a
+`FunctionWrappersWrapper` whose fallback path should reuse wrappers for several
+different fallback argument tuple types.
+
+# Examples
+
+```julia
+using FunctionWrappersWrappers
+
+wrapper = FunctionWrappersWrapper(sin, (Tuple{Float64},), (Float64,);
+    cache = DictCache(), policy = AllowAll())
+storage = FunctionWrappersWrappers.DictCacheStorage()
+```
+
+# Fields
+- `cache`: Mapping from fallback argument tuple type to cached fallback wrapper.
+
+# Returns
+- `DictCacheStorage`: Empty dictionary-backed storage for fallback wrappers.
+"""
 struct DictCacheStorage
     cache::Dict{DataType, Any}
     DictCacheStorage() = new(Dict{DataType, Any}())
 end
+
+@public NoCacheStorage, SingleCacheStorage, DictCacheStorage
 
 _make_cache_storage(::NoCache) = NoCacheStorage()
 _make_cache_storage(::SingleCache) = SingleCacheStorage()

--- a/src/FunctionWrappersWrappers.jl
+++ b/src/FunctionWrappersWrappers.jl
@@ -1,6 +1,7 @@
 module FunctionWrappersWrappers
 
 using FunctionWrappers: FunctionWrappers
+using SciMLPublic: @public
 import TruncatedStacktraces
 
 export FunctionWrappersWrapper, unwrap, wrapped_signatures, wrapped_return_types
@@ -96,10 +97,38 @@ struct AllowNonIsBits <: AbstractFallbackPolicy end
 # Cache storage types
 # ============================================================================
 struct NoCacheStorage end
+
+"""
+    SingleCacheStorage()
+
+Storage for the `SingleCache()` fallback mode.
+
+`SingleCacheStorage` stores one fallback `FunctionWrappers.FunctionWrapper`
+for the most recent argument tuple type. It is public so downstream packages
+that manually construct `FunctionWrappersWrapper` values can select the same
+single-entry cache layout used by `FunctionWrappersWrapper(...; cache = SingleCache())`.
+
+# Examples
+
+```julia
+using FunctionWrappersWrappers
+
+storage = FunctionWrappersWrappers.SingleCacheStorage()
+wrapper = FunctionWrappersWrapper(sin, (Tuple{Float64},), (Float64,);
+    cache = SingleCache())
+
+wrapper(1.0)
+```
+
+# Returns
+- `SingleCacheStorage`: Empty storage for one cached fallback wrapper.
+"""
 mutable struct SingleCacheStorage
     cached::Any  # Union{Nothing, FunctionWrapper}
     SingleCacheStorage() = new(nothing)
 end
+@public SingleCacheStorage
+
 struct DictCacheStorage
     cache::Dict{DataType, Any}
     DictCacheStorage() = new(Dict{DataType, Any}())


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Adds `SciMLPublic` and marks `SingleCacheStorage` as public without exporting it.
- Adds a source docstring for `SingleCacheStorage`; existing autodocs/rendered QA will render it.
- This gives downstream packages such as NonlinearSolveBase an owner-declared public API for the existing qualified `FunctionWrappersWrappers.SingleCacheStorage()` construction.

## Validation
- `git diff --check`
- `julia +1.10 --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/toolenvs/runic -e 'using Runic; exit(Runic.main(ARGS))' -- --check src/FunctionWrappersWrappers.jl test/qa/qa.jl docs/make.jl`\n- `julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'` (`Quality Assurance | 18 pass, 18 total`)\n- `julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` with the ignored local Julia-1.12 manifest temporarily moved aside; tests passed (`FunctionWrappersWrappers.jl | 51 pass`, `BigFloat + UnionAll | 7 pass`, `Enzyme | 68 pass`, `Mooncake | 13 pass`). Julia logged Enzyme extension-load errors during Mooncake, but the package test process exited 0 and reported tests passed.\n